### PR TITLE
fix(process_manager): pid reset when processes clear and tests fixed

### DIFF
--- a/process_manager.py
+++ b/process_manager.py
@@ -84,3 +84,5 @@ def modificar_proceso(pid, campo, valor):
 """
 def reiniciar_procesos():
     procesos.clear()
+    global next_pid
+    next_pid = 1

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,34 +8,30 @@ class TestProcessManager(unittest.TestCase):
         reiniciar_procesos()
 
     def test_crear_y_listar(self):
-        ok, msg = crear_proceso("p1", "backup", "5")
+        ok, msg = crear_proceso("backup", "5")
         self.assertTrue(ok)
-        self.assertIn("p1", listar_procesos())
-        print(msg)
-
-    def test_proceso_duplicado(self):
-        crear_proceso("p1", "backup", "5")
-        ok, msg = crear_proceso("p1", "otro", "3")
-        self.assertFalse(ok)
-        self.assertIn("ya existe", msg.lower())
+        self.assertIn("1", listar_procesos())
         print(msg)
 
     def test_eliminar(self):
-        crear_proceso("p1", "backup", "5")
-        ok, msg = eliminar_proceso("p1")
+        reiniciar_procesos()
+        crear_proceso("backup", "5")
+        ok, msg = eliminar_proceso("1")
         self.assertTrue(ok)
-        self.assertNotIn("p1", listar_procesos())
+        self.assertNotIn("1", listar_procesos())
         print(msg)
 
     def test_modificar(self):
-        crear_proceso("p1", "backup", "5")
-        ok, msg = modificar_proceso("p1", "prioridad", "10")
+        reiniciar_procesos()
+        crear_proceso("backup", "5")
+        ok, msg = modificar_proceso("1", "prioridad", "10")
         self.assertTrue(ok)
         print(msg)
 
     def test_modificar_invalido(self):
-        crear_proceso("p1", "backup", "5")
-        ok, msg = modificar_proceso("p1", "invalido", "10")
+        reiniciar_procesos()
+        crear_proceso("backup", "5")
+        ok, msg = modificar_proceso("1", "invalido", "10")
         self.assertFalse(ok)
         print(msg)
 


### PR DESCRIPTION
##What is?
Fix bug and failing tests when process list was reseted

##How to test?
python3 -m tests.test_commands

Also take in account the new format when comunicating from telnet, those are the new commands following the protocol format:
- CREAR|\<nombre\>|\<prioridad\>
- LISTAR
- ELIMINAR|\<id\>
- MODIFICAR|\<id\>|\<campo\>|\<valor\>